### PR TITLE
cleanup method signatures

### DIFF
--- a/inc/TRestWimpNucleus.h
+++ b/inc/TRestWimpNucleus.h
@@ -23,9 +23,9 @@
 #ifndef RestCore_TRestWimpNucleus
 #define RestCore_TRestWimpNucleus
 
-#include <iostream>
-
 #include <TString.h>
+
+#include <iostream>
 
 /// A class to store different nucleus parameters
 class TRestWimpNucleus {

--- a/inc/TRestWimpSensitivity.h
+++ b/inc/TRestWimpSensitivity.h
@@ -23,10 +23,9 @@
 #ifndef RestCore_TRestWimpSensitivity
 #define RestCore_TRestWimpSensitivity
 
+#include <TH1D.h>
 #include <TRestMetadata.h>
 #include <TRestWimpNucleus.h>
-
-#include <TH1D.h>
 
 /// Container class for WIMP metadata
 ///
@@ -60,7 +59,7 @@ class TRestWimpSensitivity : public TRestMetadata {
     std::map<std::string, TH1D*> quenchingFactor;  //!
 
    public:
-    TRestWimpSensitivity(const char* configFilename, const std::string& name = "");
+    explicit TRestWimpSensitivity(const char* configFilename, const std::string& name = "");
 
     ~TRestWimpSensitivity();
 
@@ -69,11 +68,11 @@ class TRestWimpSensitivity : public TRestMetadata {
     void PrintMetadata() override;
 
     void ReadNuclei();
-    const Double_t GetSensitivity(const double wimpMass);
+    const Double_t GetSensitivity(double wimpMass);
     void CalculateQuenchingFactor();
     const std::string BuildOutputFileName(const std::string& extension = ".txt");
 
-    std::map<std::string, TH1D*> GetRecoilSpectra(const double wimpMass, const double crossSection);
+    std::map<std::string, TH1D*> GetRecoilSpectra(double wimpMass, double crossSection);
     std::map<std::string, TH1D*> GetFormFactor();
     inline auto GetQuenchingFactor() { return quenchingFactor; }
 

--- a/inc/TRestWimpUtils.h
+++ b/inc/TRestWimpUtils.h
@@ -39,19 +39,17 @@ constexpr double CM2_PER_MBARN = 1e-27;
 constexpr double FERMI_CONSTANT = 1.16639e-5;  // GeV-2
 
 /// Generic functions for different calculations
-const double GetRelativeNuclearCS(const double wimpMass, const double Anum);
-const double GetReducedMass(const double wimpMass, const double Anum);
-const double GetHelmFormFactor(const double recoilEnergy, const double Anum);
-const double Bessel(const double x);
-const double GetVMin(const double wimpMass, const double Anum, const double recoilEnergy);
-const double GetVelocityDistribution(const double v, const double vLab, const double vRMS,
-                                     const double vEscape);
-const double GetDifferentialCrossSection(const double wimpMass, const double crossSection,
-                                         const double velocity, const double recoilEnergy, const double Anum);
-const double GetRecoilRate(const double wimpMass, const double crossSection, const double recoilEnergy,
-                           const double Anum, const double vLab, const double vRMS, const double vEscape,
-                           const double wimpDensity, const double abundance);
-const double GetQuenchingFactor(const double recoilEnergy, const double Anum, const double Znum);
+double GetRelativeNuclearCS(double wimpMass, double Anum);
+double GetReducedMass(double wimpMass, double Anum);
+double GetHelmFormFactor(double recoilEnergy, double Anum);
+double Bessel(double x);
+double GetVMin(double wimpMass, double Anum, double recoilEnergy);
+double GetVelocityDistribution(double v, double vLab, double vRMS, double vEscape);
+double GetDifferentialCrossSection(double wimpMass, double crossSection, double velocity, double recoilEnergy,
+                                   double Anum);
+double GetRecoilRate(double wimpMass, double crossSection, double recoilEnergy, double Anum, double vLab,
+                     double vRMS, double vEscape, double wimpDensity, double abundance);
+double GetQuenchingFactor(double recoilEnergy, double Anum, double Znum);
 
 }  // namespace TRestWimpUtils
 

--- a/src/TRestWimpNucleus.cxx
+++ b/src/TRestWimpNucleus.cxx
@@ -40,7 +40,8 @@
 ///
 
 #include "TRestWimpNucleus.h"
-#include "TRestMetadata.h"
+
+#include <TRestMetadata.h>
 
 ClassImp(TRestWimpNucleus);
 

--- a/src/TRestWimpUtils.cxx
+++ b/src/TRestWimpUtils.cxx
@@ -42,15 +42,16 @@
 /// <hr>
 ///
 
+#include "TRestWimpUtils.h"
+
 #include <TMath.h>
-#include <TRestWimpUtils.h>
 
 //////////////////////////////////////////////////
 /// \brief Get relative nuclear cross section
 /// within a WIMP and a nucleon, assuming
-/// SCALAR INTERACION
+/// SCALAR INTERACTION
 ///
-const double TRestWimpUtils::GetRelativeNuclearCS(const double wimpMass, const double Anum) {
+double TRestWimpUtils::GetRelativeNuclearCS(const double wimpMass, const double Anum) {
     const double reducedMass = GetReducedMass(wimpMass, Anum);
     const double reducedMassSingle = GetReducedMass(wimpMass, 1.);
     return pow(Anum * GEV_PER_UMA * reducedMass / reducedMassSingle, 2.);
@@ -60,7 +61,7 @@ const double TRestWimpUtils::GetRelativeNuclearCS(const double wimpMass, const d
 /// \brief Get WIMP-nucleon reduced mass
 /// (WIMP mass in GeV)
 ///
-const double TRestWimpUtils::GetReducedMass(const double wimpMass, const double Anum) {
+double TRestWimpUtils::GetReducedMass(const double wimpMass, const double Anum) {
     // WIMP mass in GeV
     return wimpMass * GEV_PER_UMA * Anum / (wimpMass + Anum * GEV_PER_UMA);
 }
@@ -70,7 +71,7 @@ const double TRestWimpUtils::GetReducedMass(const double wimpMass, const double 
 /// energy and nucleous target, mass recoil
 /// energy in keV
 ///
-const double TRestWimpUtils::GetHelmFormFactor(const double recoilEnergy, const double Anum) {
+double TRestWimpUtils::GetHelmFormFactor(const double recoilEnergy, const double Anum) {
     // Momentum transfer in keV
     const double q = sqrt(2. * Anum * GEV_PER_UMA * 1E6 * recoilEnergy);
     const double s = 0.9;  // Femtometers-Skin thickness of the nucleus
@@ -92,7 +93,7 @@ const double TRestWimpUtils::GetHelmFormFactor(const double recoilEnergy, const 
 /// for a WIMP to create a recoil energy (keV)
 /// higher than recoilEnergy
 ///
-const double TRestWimpUtils::GetVMin(const double wimpMass, const double Anum, const double recoilEnergy) {
+double TRestWimpUtils::GetVMin(const double wimpMass, const double Anum, const double recoilEnergy) {
     const double reducedMass = GetReducedMass(wimpMass, Anum);
     return sqrt(Anum * GEV_PER_UMA * recoilEnergy * 1E-6 / (2. * reducedMass * reducedMass)) * LIGHT_SPEED;
 }
@@ -101,8 +102,8 @@ const double TRestWimpUtils::GetVMin(const double wimpMass, const double Anum, c
 /// \brief Get velocity distribution for a given
 /// WIMP velocity
 ///
-const double TRestWimpUtils::GetVelocityDistribution(const double v, const double vLab, const double vRMS,
-                                                     const double vEscape) {
+double TRestWimpUtils::GetVelocityDistribution(const double v, const double vLab, const double vRMS,
+                                               const double vEscape) {
     const double vAdim = vRMS / vLab;
     const double Nesc = erf(vAdim) - (2. / sqrt(TMath::Pi())) * (vAdim)*exp(-vAdim * vAdim);
     const double xMax = std::min(1., (vEscape * vEscape - vLab * vLab - v * v) / (2. * vLab * v));
@@ -118,9 +119,9 @@ const double TRestWimpUtils::GetVelocityDistribution(const double v, const doubl
 /// nucleon in cm^2, Anum in atomic units (amu)
 /// (or atomic weight)
 ///
-const double TRestWimpUtils::GetDifferentialCrossSection(const double wimpMass, const double crossSection,
-                                                         const double velocity, const double recoilEnergy,
-                                                         const double Anum) {
+double TRestWimpUtils::GetDifferentialCrossSection(const double wimpMass, const double crossSection,
+                                                   const double velocity, const double recoilEnergy,
+                                                   const double Anum) {
     const double cs = GetRelativeNuclearCS(wimpMass, Anum) * crossSection;
     const double reducedMass = GetReducedMass(wimpMass, Anum);
     const double Emax = 1E6 / LIGHT_SPEED / LIGHT_SPEED * 2. * reducedMass * reducedMass * velocity *
@@ -135,10 +136,10 @@ const double TRestWimpUtils::GetDifferentialCrossSection(const double wimpMass, 
 /// and recoil energy, note that the recoil rate
 /// is normalized by c/kg/day
 ///
-const double TRestWimpUtils::GetRecoilRate(const double wimpMass, const double crossSection,
-                                           const double recoilEnergy, const double Anum, const double vLab,
-                                           const double vRMS, const double vEscape, const double wimpDensity,
-                                           const double abundance) {
+double TRestWimpUtils::GetRecoilRate(const double wimpMass, const double crossSection,
+                                     const double recoilEnergy, const double Anum, const double vLab,
+                                     const double vRMS, const double vEscape, const double wimpDensity,
+                                     const double abundance) {
     const double vMin = GetVMin(wimpMass, Anum, recoilEnergy);
     const double vMax = vEscape + vLab;
     const double nNuclei = abundance * N_AVOGADRO * 1E3 / Anum;  // Number of atoms
@@ -163,8 +164,7 @@ const double TRestWimpUtils::GetRecoilRate(const double wimpMass, const double c
 /// \brief Get Lindhard quenching factor for a
 /// given recoil energy (keV) and target
 ///
-const double TRestWimpUtils::GetQuenchingFactor(const double recoilEnergy, const double Anum,
-                                                const double Znum) {
+double TRestWimpUtils::GetQuenchingFactor(const double recoilEnergy, const double Anum, const double Znum) {
     const double deltaE = 0.0001, Emin = 0.1, resolution = 0.1;  // keV
     double g, Er = recoilEnergy, Ev;
 


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 36](https://badgen.net/badge/PR%20Size/Ok%3A%2036/green)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Since the codebase for this repository is still small I think its a good opportunity to do define some guidelines regarding style that could also be applied on other REST-for-Physics repositories. It may be useful to new contributors such as @AlvaroEzq or @Anakintana.

- Using `const` on the return type is generally not recommened (I have done it on the past myself, before I learned this). See https://stackoverflow.com/questions/1579435/should-useless-type-qualifiers-on-return-types-be-used-for-clarity for more details, but basically it does nothing, it can be viewed as a hint to whoever reads the code but generally its not worth polluting the codebase for this (you could just add a comment if it was really important I guess).

- Funcion declarations (header file) do not need to have parameters marked as `const`, this is only required in the definition (source file). In general it is recommended to only mark them `const` in the definition. See https://stackoverflow.com/questions/38660537/why-is-const-unnecessary-in-function-declarations-in-header-files-for-parameters for more details.