### PR TITLE
Separating framework and wimplib pipelines in diferent workflows

### DIFF
--- a/.github/workflows/frameworkValidation.yml
+++ b/.github/workflows/frameworkValidation.yml
@@ -1,0 +1,23 @@
+name: Framework Validation
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  release:
+
+  workflow_dispatch:
+
+env:
+  CMAKE_BUILD_TYPE: Release
+  REST_PATH: /rest/wimplib/install
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  framework-validation:
+    uses: rest-for-physics/framework/.github/workflows/validation.yml@submodule-validation

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -22,8 +22,7 @@ jobs:
       image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     steps:
       - uses: actions/checkout@v3
-      - name: Checkout wimplib
-        uses: rest-for-physics/framework/.github/actions/checkout@submodule-validation
+      - uses: rest-for-physics/framework/.github/actions/checkout@submodule-validation
         with:
           branch: ${{ env.BRANCH_NAME }}
           repository: rest-for-physics/wimplib

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,13 +1,8 @@
 name: Validation
 
 on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
-  release:
-
   workflow_dispatch:
+  workflow_call:
 
 env:
   CMAKE_BUILD_TYPE: Release
@@ -19,8 +14,6 @@ defaults:
     shell: bash
 
 jobs:
-  framework-validation:
-    uses: rest-for-physics/framework/.github/workflows/validation.yml@master
 
   build-wimplib:
     name: Build only wimplib

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -18,7 +18,10 @@ jobs:
   precommit-config:
     name: Validate pre-commit config
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     steps:
+      - name: Checkout wimplib
       - uses: rest-for-physics/framework/.github/actions/checkout@submodule-validation
         with:
           branch: ${{ env.BRANCH_NAME }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -21,8 +21,8 @@ jobs:
     container:
       image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     steps:
-      - uses: actions/checkout@v3
-      - uses: rest-for-physics/framework/.github/actions/checkout@submodule-validation
+      - name: Checkout wimplib
+        uses: rest-for-physics/framework/.github/actions/checkout@submodule-validation
         with:
           branch: ${{ env.BRANCH_NAME }}
           repository: rest-for-physics/wimplib
@@ -39,7 +39,7 @@ jobs:
       image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     steps:
       - name: Build and install
-      - uses: rest-for-physics/framework/.github/actions/build@master
+        uses: rest-for-physics/framework/.github/actions/build@master
         with:
           cmake-flags: "-DCMAKE_INSTALL_PREFIX=${{ env.REST_PATH }} -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DREST_WELCOME=ON -DRESTLIB_WIMP=ON"
           branch: ${{ env.BRANCH_NAME }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -21,8 +21,9 @@ jobs:
     container:
       image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     steps:
+      - uses: actions/checkout@v3
       - name: Checkout wimplib
-      - uses: rest-for-physics/framework/.github/actions/checkout@submodule-validation
+        uses: rest-for-physics/framework/.github/actions/checkout@submodule-validation
         with:
           branch: ${{ env.BRANCH_NAME }}
           repository: rest-for-physics/wimplib

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -15,12 +15,9 @@ defaults:
     shell: bash
 
 jobs:
-
-  build-wimplib:
-    name: Build only wimplib
+  precommit-config:
+    name: Validate pre-commit config
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     steps:
       - uses: rest-for-physics/framework/.github/actions/checkout@submodule-validation
         with:
@@ -31,8 +28,15 @@ jobs:
         run: |
           cd ${{ env.WIMP_LIB_PATH }}
           curl https://raw.githubusercontent.com/rest-for-physics/framework/master/scripts/validatePreCommitConfig.py | python
+
+  build-wimplib:
+    name: Build only wimplib
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
+    steps:
       - name: Build and install
-        uses: rest-for-physics/framework/.github/actions/build@master
+      - uses: rest-for-physics/framework/.github/actions/build@master
         with:
           cmake-flags: "-DCMAKE_INSTALL_PREFIX=${{ env.REST_PATH }} -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DREST_WELCOME=ON -DRESTLIB_WIMP=ON"
           branch: ${{ env.BRANCH_NAME }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -7,6 +7,7 @@ on:
 env:
   CMAKE_BUILD_TYPE: Release
   REST_PATH: /rest/wimplib/install
+  WIMP_LIB_PATH: wimplib
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 defaults:
@@ -21,16 +22,20 @@ jobs:
     container:
       image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     steps:
-      - uses: actions/checkout@v3
+      - uses: rest-for-physics/framework/.github/actions/checkout@submodule-validation
+        with:
+          branch: ${{ env.BRANCH_NAME }}
+          repository: rest-for-physics/wimplib
+          path: ${{ env.WIMP_LIB_PATH }}
+      - name: Verify pre-commit config files match
+        run: |
+          cd ${{ env.WIMP_LIB_PATH }}
+          curl https://raw.githubusercontent.com/rest-for-physics/framework/master/scripts/validatePreCommitConfig.py | python
       - name: Build and install
         uses: rest-for-physics/framework/.github/actions/build@master
         with:
           cmake-flags: "-DCMAKE_INSTALL_PREFIX=${{ env.REST_PATH }} -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DREST_WELCOME=ON -DRESTLIB_WIMP=ON"
           branch: ${{ env.BRANCH_NAME }}
-      - name: Verify pre-commit config files match
-        run: |
-          cd $GITHUB_WORKSPACE
-          curl https://raw.githubusercontent.com/rest-for-physics/framework/master/scripts/validatePreCommitConfig.py | python
       - name: Cache framework installation
         id: wimplib-install-cache
         uses: actions/cache@v3


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 41](https://badgen.net/badge/PR%20Size/Ok%3A%2041/green)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

These changes are required to avoid concurrency inside submodule validation that is now triggered from framework:

Separated validation files for framework and submodules

Contributes to https://github.com/rest-for-physics/framework/issues/372