### PR TITLE
Functionality for setting nuclei targets abundances in mol (volume) and as chemical compound

### DIFF
--- a/examples/WIMP.rml
+++ b/examples/WIMP.rml
@@ -10,7 +10,7 @@
         <parameter name="escapeVelocity" value="544"/>
         <parameter name="exposure" value="116.8"/>
         <parameter name="background" value="1"/>
-        <parameter name="energySpectra" value="(0,2)"/>
+        <parameter name="energySpectra" value="(0,4)"/>
         <parameter name="energySpectraStep" value="0.01"/>
         <parameter name="energyRange" value="(0.1,1.1)"/>
         <parameter name="useQuenchingFactor" value="true"/>

--- a/examples/WIMP_compound_1.rml
+++ b/examples/WIMP_compound_1.rml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wimp>
+    <TRestWimpSensitivity name="WIMPSensitivity" title="WIMP Sensitivity" verboseLevel="info">
+        <addElement nucleusName="Ar" anum="39.948" znum="18" abundanceInMol="0.99"/>
+        <addCompound compoundName="C4H10" abundanceInMol="0.01">
+            <addElement nucleusName="C" anum="12.0107" znum="6" />
+            <addElement nucleusName="H" anum="1.00784" znum="1" />
+        </addCompound>
+        <parameter name="wimpDensity" value="0.3"/>
+        <parameter name="labVelocity" value="232"/>
+        <parameter name="rmsVelocity" value="220"/>
+        <parameter name="escapeVelocity" value="544"/>
+        <parameter name="exposure" value="116.8"/>
+        <parameter name="background" value="100"/>
+        <parameter name="energySpectra" value="(0,8)"/>
+        <parameter name="energySpectraStep" value="0.01"/>
+        <parameter name="energyRange" value="(0.05,1.05)"/>
+        <parameter name="useQuenchingFactor" value="true"/>
+    </TRestWimpSensitivity>
+</wimp>

--- a/examples/WIMP_compound_2.rml
+++ b/examples/WIMP_compound_2.rml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wimp>
+    <TRestWimpSensitivity name="WIMPSensitivity" title="WIMP Sensitivity" verboseLevel="info">
+        <addCompound compoundName="Ar99(C4H10)1" abundanceInMol="1">
+            <addElement nucleusName="Ar" anum="39.948" znum="18"/>
+            <addElement nucleusName="C" anum="12.0107" znum="6" />
+            <addElement nucleusName="H" anum="1.00784" znum="1" />
+        </addCompound>
+        <parameter name="wimpDensity" value="0.3"/>
+        <parameter name="labVelocity" value="232"/>
+        <parameter name="rmsVelocity" value="220"/>
+        <parameter name="escapeVelocity" value="544"/>
+        <parameter name="exposure" value="116.8"/>
+        <parameter name="background" value="100"/>
+        <parameter name="energySpectra" value="(0,8)"/>
+        <parameter name="energySpectraStep" value="0.01"/>
+        <parameter name="energyRange" value="(0.05,1.05)"/>
+        <parameter name="useQuenchingFactor" value="true"/>
+    </TRestWimpSensitivity>
+</wimp>

--- a/inc/TRestWimpNucleus.h
+++ b/inc/TRestWimpNucleus.h
@@ -38,7 +38,7 @@ class TRestWimpNucleus {
     Int_t fZnum;
     /// Abundance, in mass percentage
     Double_t fAbundance;
-    /// Abundance, in mole (or volume) percentage
+    /// Abundance, in mole (or volume)
     Double_t fAbundanceMol;
 
     void PrintNucleus();

--- a/inc/TRestWimpNucleus.h
+++ b/inc/TRestWimpNucleus.h
@@ -38,8 +38,11 @@ class TRestWimpNucleus {
     Int_t fZnum;
     /// Abundance, in mass percentage
     Double_t fAbundance;
+    /// Abundance, in mole (or volume) percentage
+    Double_t fAbundanceMol;
 
     void PrintNucleus();
+    int GetStechiometricFactorFromCompound(const std::string& compound);
 
     // Constructor
     TRestWimpNucleus();
@@ -47,7 +50,7 @@ class TRestWimpNucleus {
     // Destructor
     virtual ~TRestWimpNucleus();
 
-    ClassDef(TRestWimpNucleus, 1);
+    ClassDef(TRestWimpNucleus, 2);
 };
 
 #endif

--- a/inc/TRestWimpUtils.h
+++ b/inc/TRestWimpUtils.h
@@ -21,6 +21,7 @@
  *************************************************************************/
 
 #include <iostream>
+#include <map>
 
 #ifndef RestCore_TRestWimpUtils
 #define RestCore_TRestWimpUtils
@@ -54,7 +55,7 @@ const double GetRecoilRate(const double wimpMass, const double crossSection, con
                            const double Anum, const double vLab, const double vRMS, const double vEscape,
                            const double wimpDensity, const double abundance);
 const double GetQuenchingFactor(const double recoilEnergy, const double Anum, const double Znum);
-
+std::map<std::string, int> ParseChemicalCompound(const std::string& compound);
 }  // namespace TRestWimpUtils
 
 #endif

--- a/src/TRestWimpNucleus.cxx
+++ b/src/TRestWimpNucleus.cxx
@@ -40,12 +40,19 @@
 ///
 
 #include "TRestWimpNucleus.h"
+#include "TRestWimpUtils.h"
 
 #include "TRestMetadata.h"
 
 ClassImp(TRestWimpNucleus);
 
-TRestWimpNucleus::TRestWimpNucleus() {}
+TRestWimpNucleus::TRestWimpNucleus() {
+    fNucleusName = "";
+    fAnum = 0;
+    fZnum = 0;
+    fAbundance = 0;
+    fAbundanceMol = 0;
+}
 
 TRestWimpNucleus::~TRestWimpNucleus() {}
 
@@ -55,5 +62,23 @@ void TRestWimpNucleus::PrintNucleus() {
     RESTMetadata << "Atomic number " << fAnum << RESTendl;
     RESTMetadata << "Number of protons " << fZnum << RESTendl;
     RESTMetadata << "Abundance " << fAbundance << RESTendl;
+    RESTMetadata << "Abundance (mol) " << fAbundanceMol << RESTendl;
     RESTMetadata << "-----------------------------" << RESTendl;
+}
+
+int TRestWimpNucleus::GetStechiometricFactorFromCompound(const std::string& compound) {
+
+    auto elementMap = TRestWimpUtils::ParseChemicalCompound(compound);
+
+    int stechiometricFactor = 0;
+    for (auto& pair : elementMap) {
+        if (pair.first == fNucleusName.Data()) {
+            stechiometricFactor = pair.second;
+            break;
+        }
+    }
+    if (stechiometricFactor == 0)
+        RESTWarning << "No nucleus " << fNucleusName.Data() << " founnd in compound " << compound << RESTendl;
+    
+    return stechiometricFactor;
 }

--- a/src/TRestWimpNucleus.cxx
+++ b/src/TRestWimpNucleus.cxx
@@ -66,6 +66,12 @@ void TRestWimpNucleus::PrintNucleus() {
     RESTMetadata << "-----------------------------" << RESTendl;
 }
 
+///////////////////////////////////////////////
+/// \brief Get the stechiometric factor of this nucleus in a given compound.
+///
+/// \param compound The compound to be parsed. See
+/// TRestWimpUtils::ParseChemicalCompound for the compound format.
+///
 int TRestWimpNucleus::GetStechiometricFactorFromCompound(const std::string& compound) {
     auto elementMap = TRestWimpUtils::ParseChemicalCompound(compound);
 

--- a/src/TRestWimpNucleus.cxx
+++ b/src/TRestWimpNucleus.cxx
@@ -40,9 +40,9 @@
 ///
 
 #include "TRestWimpNucleus.h"
-#include "TRestWimpUtils.h"
 
 #include "TRestMetadata.h"
+#include "TRestWimpUtils.h"
 
 ClassImp(TRestWimpNucleus);
 
@@ -67,7 +67,6 @@ void TRestWimpNucleus::PrintNucleus() {
 }
 
 int TRestWimpNucleus::GetStechiometricFactorFromCompound(const std::string& compound) {
-
     auto elementMap = TRestWimpUtils::ParseChemicalCompound(compound);
 
     int stechiometricFactor = 0;
@@ -79,6 +78,6 @@ int TRestWimpNucleus::GetStechiometricFactorFromCompound(const std::string& comp
     }
     if (stechiometricFactor == 0)
         RESTWarning << "No nucleus " << fNucleusName.Data() << " founnd in compound " << compound << RESTendl;
-    
+
     return stechiometricFactor;
 }

--- a/src/TRestWimpSensitivity.cxx
+++ b/src/TRestWimpSensitivity.cxx
@@ -37,6 +37,8 @@
 /// - *anum* : Atomic number of the nucleus
 /// - *znum* : Number of protons in the nucleus
 /// - *abundance* : Mass percentage of the nucleus in the target material.
+/// - *abundanceInMol* : Mol (or volume) percentage of the nucleus in the
+/// target material.
 /// - *wimpDensity* : WIMP density in the DM halo in GeV/cm3
 /// - *labVelocity* : WIMP velocity in the lab (Earth) frame reference
 /// in km/s
@@ -282,7 +284,8 @@ void TRestWimpSensitivity::ReadNuclei() {
 ///////////////////////////////////////////////
 /// \brief Get recoil spectra for a given WIMP
 /// mass and cross section
-/// Better performance version
+/// Better performance version (velocity integral
+/// is done only once for all recoil energies).
 ///
 std::map<std::string, TH1D*> TRestWimpSensitivity::GetRecoilSpectra(const double wimpMass,
                                                                     const double crossSection) {

--- a/src/TRestWimpSensitivity.cxx
+++ b/src/TRestWimpSensitivity.cxx
@@ -177,10 +177,12 @@ void TRestWimpSensitivity::ReadNuclei() {
         nucleus.fAnum = StringToDouble(GetFieldValue("anum", ElementDef));
         nucleus.fZnum = StringToInteger(GetFieldValue("znum", ElementDef));
 
-        std::string el = !ElementDef->Attribute("abundance") ? "Not defined" : ElementDef->Attribute("abundance");
+        std::string el =
+            !ElementDef->Attribute("abundance") ? "Not defined" : ElementDef->Attribute("abundance");
         if (!(el.empty() || el == "Not defined")) nucleus.fAbundance = StringToDouble(el);
 
-        el = !ElementDef->Attribute("abundanceInMol") ? "Not defined" : ElementDef->Attribute("abundanceInMol");
+        el = !ElementDef->Attribute("abundanceInMol") ? "Not defined"
+                                                      : ElementDef->Attribute("abundanceInMol");
         if (!(el.empty() || el == "Not defined")) {
             nucleus.fAbundanceMol = StringToDouble(el);
             anyAbundanceGivenInMol = true;
@@ -192,8 +194,8 @@ void TRestWimpSensitivity::ReadNuclei() {
             else if (nucleus.fAbundanceMol == 0)
                 nucleus.fAbundanceMol = nucleus.fAbundance / nucleus.fAnum;
             else
-                RESTError << "abundance or abundanceInMol not defined for nucleus "
-                          << nucleus.fNucleusName << RESTendl;
+                RESTError << "abundance or abundanceInMol not defined for nucleus " << nucleus.fNucleusName
+                          << RESTendl;
         }
         fNuclei.emplace_back(nucleus);
         ElementDef = GetNextElement(ElementDef);
@@ -202,16 +204,17 @@ void TRestWimpSensitivity::ReadNuclei() {
     // Read nuclei (compound form given) elements
     TiXmlElement* CompoundDef = GetElement("addCompound");
     while (CompoundDef) {
-
         bool compoundAbundanceGivenInMol = false;
         std::string compoundName = GetFieldValue("compoundName", CompoundDef);
         double compoundAbundance = 0, compoundAbundanceInMol = 0;
         double totalMolMass = 0;
 
-        std::string el = !CompoundDef->Attribute("abundance") ? "Not defined" : CompoundDef->Attribute("abundance");
+        std::string el =
+            !CompoundDef->Attribute("abundance") ? "Not defined" : CompoundDef->Attribute("abundance");
         if (!(el.empty() || el == "Not defined")) compoundAbundance = StringToDouble(el);
 
-        el = !CompoundDef->Attribute("abundanceInMol") ? "Not defined" : CompoundDef->Attribute("abundanceInMol");
+        el = !CompoundDef->Attribute("abundanceInMol") ? "Not defined"
+                                                       : CompoundDef->Attribute("abundanceInMol");
         if (!(el.empty() || el == "Not defined")) {
             compoundAbundanceInMol = StringToDouble(el);
             compoundAbundanceGivenInMol = true;
@@ -224,8 +227,8 @@ void TRestWimpSensitivity::ReadNuclei() {
             compoundAbundanceInMol = 1;
         }
 
-         // Read nuclei (inside compound) elements
-        TiXmlElement *ElementDef = GetElement("addElement", CompoundDef);
+        // Read nuclei (inside compound) elements
+        TiXmlElement* ElementDef = GetElement("addElement", CompoundDef);
         int i = 0;
         while (ElementDef) {
             i++;
@@ -243,7 +246,7 @@ void TRestWimpSensitivity::ReadNuclei() {
         else
             compoundAbundanceInMol = compoundAbundance / totalMolMass;
         // Set the compound abundance to all nuclei elements inside the compound
-        for (auto it = fNuclei.end() -i; it != fNuclei.end(); it++) {
+        for (auto it = fNuclei.end() - i; it != fNuclei.end(); it++) {
             auto& nucleus = *it;
             int stechiometricFactor = nucleus.GetStechiometricFactorFromCompound(compoundName);
             nucleus.fAbundanceMol = compoundAbundanceInMol * stechiometricFactor;
@@ -260,14 +263,14 @@ void TRestWimpSensitivity::ReadNuclei() {
         if (uniqueNucleiMap.find(key) != uniqueNucleiMap.end()) {
             uniqueNucleiMap[key].fAbundance += nucleus.fAbundance;
             uniqueNucleiMap[key].fAbundanceMol += nucleus.fAbundanceMol;
-        } else uniqueNucleiMap[key] = nucleus;
+        } else
+            uniqueNucleiMap[key] = nucleus;
     }
     fNuclei.clear();
-    for (const auto& entry : uniqueNucleiMap)
-        fNuclei.push_back(entry.second);
+    for (const auto& entry : uniqueNucleiMap) fNuclei.push_back(entry.second);
 
-    //normalize fAbundance (in mass only) if anyAbundanceGivenInMol
-    if (anyAbundanceGivenInMol){
+    // normalize fAbundance (in mass only) if anyAbundanceGivenInMol
+    if (anyAbundanceGivenInMol) {
         double sumMass = 0;
         for (auto& nucl : fNuclei) sumMass += nucl.fAbundance;
         for (auto& nucl : fNuclei) nucl.fAbundance /= sumMass;

--- a/src/TRestWimpUtils.cxx
+++ b/src/TRestWimpUtils.cxx
@@ -221,8 +221,8 @@ std::map<std::string, int> TRestWimpUtils::ParseChemicalCompound(const std::stri
     std::map<std::string, int> elementMap;
     std::string elementName;
     int coefficient = 1;
-    
-    for (size_t i = 0; i < compound.size(); ) {
+
+    for (size_t i = 0; i < compound.size();) {
         // Check for uppercase letter (start of an element)
         if (std::isupper(compound[i])) {
             elementName = compound[i];
@@ -244,15 +244,14 @@ std::map<std::string, int> TRestWimpUtils::ParseChemicalCompound(const std::stri
             }
             // Add the element and coefficient to the map
             elementMap[elementName] += coefficient;
-        }
-        else if (compound[i] == '(') { // Check for a subCompound inside parentheses
+        } else if (compound[i] == '(') {  // Check for a subCompound inside parentheses
             i++;
             std::string subCompound;
             while (i < compound.size() && compound[i] != ')') {
                 subCompound += compound[i];
                 i++;
             }
-            i++; // Move past the closing parenthesis
+            i++;  // Move past the closing parenthesis
             // Find the subscript after the closing parenthesis
             coefficient = 1;
             if (i < compound.size() && std::isdigit(compound[i])) {
@@ -267,8 +266,7 @@ std::map<std::string, int> TRestWimpUtils::ParseChemicalCompound(const std::stri
             for (auto& pair : subElementMap) {
                 elementMap[pair.first] += pair.second * coefficient;
             }
-        }
-        else 
+        } else
             i++;
     }
     return elementMap;

--- a/src/TRestWimpUtils.cxx
+++ b/src/TRestWimpUtils.cxx
@@ -223,9 +223,9 @@ const double TRestWimpUtils::GetQuenchingFactor(const double recoilEnergy, const
 std::map<std::string, int> TRestWimpUtils::ParseChemicalCompound(const std::string& compound) {
     std::map<std::string, int> elementMap;
     std::string elementName;
-    int coefficient = 1;
 
     for (size_t i = 0; i < compound.size();) {
+        int coefficient = 1;
         // Check for uppercase letter (start of an element)
         if (std::isupper(compound[i])) {
             elementName = compound[i];

--- a/src/TRestWimpUtils.cxx
+++ b/src/TRestWimpUtils.cxx
@@ -215,7 +215,10 @@ const double TRestWimpUtils::GetQuenchingFactor(const double recoilEnergy, const
 /// subCompound. The subCompound can have a
 /// coefficient after the closing parenthesis.
 /// The function is recursive, so subCompounds
-/// can contain subCompounds.
+/// can contain subCompounds. Examples:
+/// "H2O" -> {"H": 2, "O": 1}
+/// "Ne98(C4H10)2" -> {"Ne": 98, "C": 8, "H": 20}
+/// "C6H5CH(CH3)2" -> {"C": 9, "H": 12}
 ///
 std::map<std::string, int> TRestWimpUtils::ParseChemicalCompound(const std::string& compound) {
     std::map<std::string, int> elementMap;

--- a/src/TRestWimpUtils.cxx
+++ b/src/TRestWimpUtils.cxx
@@ -223,6 +223,17 @@ const double TRestWimpUtils::GetQuenchingFactor(const double recoilEnergy, const
 std::map<std::string, int> TRestWimpUtils::ParseChemicalCompound(const std::string& compound) {
     std::map<std::string, int> elementMap;
     std::string elementName;
+    // Get the number of opnening and closing parentheses
+    std::pair<int, int> parenthesisCount = {0, 0};
+    for (size_t i = 0; i < compound.size();) {
+        if (compound[i] == '(') parenthesisCount.first++;
+        if (compound[i] == ')') parenthesisCount.second++;
+        i++;
+    }
+    if (parenthesisCount.first != parenthesisCount.second) {
+        std::cout << "Error: Parentheses in compound " << compound << " do not match." << std::endl;
+        return elementMap;  // empty map
+    }
 
     for (size_t i = 0; i < compound.size();) {
         int coefficient = 1;
@@ -250,7 +261,13 @@ std::map<std::string, int> TRestWimpUtils::ParseChemicalCompound(const std::stri
         } else if (compound[i] == '(') {  // Check for a subCompound inside parentheses
             i++;
             std::string subCompound;
-            while (i < compound.size() && compound[i] != ')') {
+            while (i < compound.size()) {
+                if (compound[i] == ')') {
+                    if (parenthesisCount.second > 1)
+                        parenthesisCount.second--;
+                    else
+                        break;
+                }
                 subCompound += compound[i];
                 i++;
             }


### PR DESCRIPTION
![AlvaroEzq](https://badgen.net/badge/PR%20submitted%20by%3A/AlvaroEzq/blue) ![Large: 272](https://badgen.net/badge/PR%20Size/Large%3A%20272/red) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Adding other ways to define the target material. Now it is possible to define (chemical) compounds. Also, the abundances can be given in mol (or volume) using the parameter *abundanceInMol* instead of *abundance*. Examples for an Ar+Isobutane mixture at 99% in volume can be found inside the files ['REST_PATH/source/libraries/wimp/examples/WIMP_compound_1.rml'](examples/WIMP_compound_1.rml) and ['REST_PATH/source/libraries/wimp/examples/WIMP_compound_2.rml'](examples/WIMP_compound_2.rml).

 So now, there are three ways of setting the abundance with rml files:

1.  Old way, by only setting 'abundance' for each nucleus. The behaviour of the code in this case doesn't change respect to before this PR. The *abundance* is directly put into  (no normalization) and `fAbundanceInMol` is just ` fAbundance/fAnum`
2.  New way, by setting *abundanceInMol* for each nucleus or compound. In this case, the `fAbundance` will be the relative amount of mass of each nucleus (normalized to 1).
3.  Other ways where some elements (or compounds) abundances are given with *abundance* and others with *abundanceInMol* are not recommended, although they can be handled. In this cases, *abundance* is then understood as the absolute mass (in grams) and the *abundanceInMol* as the absolute number of moles of their corresponding element or compound. Finally, `fAbundance` is normalized, so the `fAbundance` of each nucleus is the relative amount of mass of that nucleus.

### The new *addCompound* structure

Compounds are meant to be written in the following way
```
<addCompound compoundName="C4H10" abundanceInMol="0.01">
            <addElement nucleusName="C" anum="12.0107" znum="6" />
            <addElement nucleusName="H" anum="1.00784" znum="1" />
</addCompound>
```
Where compoundName is the chemical formula and abundance or abundanceInMol the corresponding abundance of the whole compound. Inside the addCompound structure, there must be defined each element of the chemical formula, where the nucleusName must match with the one of the chemical formula and their anum and znum must be provided (even if there have been previously given in other compounds or standalone elements).

There is no problem on adding the same nucleus within different *addElement* or *addCompound*. If there are several `TRestWimpNucleus` with the same `fNucleusName`, `fAnum` and `fZnum`, they will be merged by summing their `fAbundance` and `fAbundanceInMol`.

### The new *abundanceInMol* parameter 
To add the possibility of descrbing the gas mixture in volume terms, the abundanceInMol parameter should be use. For this, the new member `fAbundanceInMol` of TRestWimpNucleus is proposed. The purpose of this member is double:

1. To store this parameter *abundanceInMol* given in the rml file (so the sensitivity calculated can be reproduced by inspecting the TRestWimpSensitivity metadata) 
2. To serve as bridge between abundances given with *abundance* and *abundanceInMol*.

It is important to notice that for all calculations, `fAbundance` remains the member to be used in the sensitivity (and recoil spectra) functions. 

Although `fAbundance` meaning is the relative amount of mass of the corresponding nucleus in the mixture, it is useful to do not normalize it, so it can be used as absolute mass (in kg) of that nucleus inside the function GetRecoilSpectra() to generate the independent spectrum of several nuclei ( idem, in units of c/keV/day/kg where kg is kg of each nucleus and not of the mixture of all the nuclei). To mantain this option available, `fAbundance` is not normalize if ALL the abundances in the rml file are set through the *abundance* paremeter. If any element or compound has *abundanceInMol*, then `anyGivenAbundanceInMol=true` inside `TRestWimpSensitivity::ReadNuclei()` and `fAbundance` will be normalized.